### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Dumper/README.md
+++ b/Dumper/README.md
@@ -2,13 +2,13 @@ GitDumper
 =================
 This is a tool for downloading .git repositories from webservers which do not have directory listing enabled. 
 
-#Requirements
+# Requirements
 - git
 - curl
 - bash
 - sed
 
-#Usage
+# Usage
 
 ```
 bash gitdumper.sh http://target.tld/.git/ dest-dir

--- a/Finder/README.md
+++ b/Finder/README.md
@@ -3,7 +3,7 @@ GitFinder
 This python script identifies websites with publicly accessible ```.git``` repositories. 
 It checks if the ```.git/HEAD``` file contains ```refs/heads```. 
 
-#Usage
+# Usage
 
 ```
 > python gitfinder.py -h

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains three small python/bash scripts used for the Git resear
 
 You can use this tool to find websites with their .git repository available to the public
 
-###Usage
+### Usage
 
 This python script identifies websites with publicly accessible ```.git``` repositories.
 It checks if the ```.git/HEAD``` file contains ```refs/heads```.
@@ -33,7 +33,7 @@ The script will output discovered domains in the form of ```[*] Found: DOMAIN```
 
 This tool can be used to download as much as possible from the found .git repository from webservers which do not have directory listing enabled.
 
-###Usage
+### Usage
 
 ```
 ./gitdumper.sh http://target.tld/.git/ dest-dir


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
