### PR TITLE
Add "-L" argument to curl command to follow page redirects

### DIFF
--- a/Dumper/gitdumper.sh
+++ b/Dumper/gitdumper.sh
@@ -112,7 +112,7 @@ function download_item() {
     fi
 
     #Download file
-    curl -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36" -f -k -s "$url" -o "$target"
+    curl -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36" -f -k -s "$url" -o "$target"
     
     #Mark as downloaded and remove it from the queue
     DOWNLOADED+=("$objname")


### PR DESCRIPTION
gitdumper.sh will download generic 301 error pages even if it links to the correct file. I've found that adding -L flag to curl command follows redirects and correctly downloads the git repository.