### PR TITLE
Added timeout of 5 seconds for request

### DIFF
--- a/Finder/gitfinder.py
+++ b/Finder/gitfinder.py
@@ -8,7 +8,7 @@ def findgitrepo(domain):
     
     try:
         # Try to download http://target.tld/.git/HEAD
-        req = urlopen('http://' + domain + "/.git/HEAD")
+        req = urlopen('http://' + domain + "/.git/HEAD", timeout=5)
         answer = req.read(200).decode()
         
         # Check if refs/heads is in the file


### PR DESCRIPTION
Nice tool, thank you.
When scanning on an internal network, if the target host is fire-walled on that port (80) it appears as if the script hangs while it waits to time out.
I just added a timeout of 5 seconds to allow it continue scanning through the list of hosts if this happens.