### PR TITLE
Add ValueError exception handling

### DIFF
--- a/Finder/gitfinder.py
+++ b/Finder/gitfinder.py
@@ -34,6 +34,8 @@ def findgitrepo(output_file, domains):
         return
     except ConnectionResetError:
         return
+    except ValueError:
+        return
     except (KeyboardInterrupt, SystemExit):
         raise
 


### PR DESCRIPTION
Fix the following error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/http/client.py", line 293, in _read_status
    status = int(status)
ValueError: invalid literal for int() with base 10: '404:'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "./gitfinder.py", line 26, in findgitrepo
    with urlopen(''.join(['http://', domain, '/.git/HEAD']), context=ssl._create_unverified_context(), timeout=5) as response:
  File "/usr/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/lib/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.6/urllib/request.py", line 564, in error
    result = self._call_chain(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 756, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/lib/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/lib/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 1368, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/usr/lib/python3.6/urllib/request.py", line 1328, in do_open
    r = h.getresponse()
  File "/usr/lib/python3.6/http/client.py", line 1356, in getresponse
    response.begin()
  File "/usr/lib/python3.6/http/client.py", line 307, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.6/http/client.py", line 297, in _read_status
    raise BadStatusLine(line)
http.client.BadStatusLine: HTTP/1.1 404: Not Found

"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "./gitfinder.py", line 93, in <module>
    main()
  File "./gitfinder.py", line 89, in main
    pool.map(fun, domains)
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 266, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
http.client.BadStatusLine: HTTP/1.1 404: Not Found
```