### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here's a small demo of the **Dumper** tool:
 * curl
 * bash
 * sed
+* binutils (strings)
 
 # License
 


### PR DESCRIPTION
Add binutils(strings) as dependencies 'cause it isn't pre-installed in some *nix and it's used by `gitdumper.sh` on line 154.