### PR TITLE
Remove unnecessary uses of '$?' in bash(1) scripts

### DIFF
--- a/Dumper/gitdumper.sh
+++ b/Dumper/gitdumper.sh
@@ -106,8 +106,7 @@ function download_item() {
     local target="$BASEGITDIR$objname"
 
     #Create folder
-    dir=$(echo "$objname" | grep -oE "^(.*)/")
-    if [ $? -ne 1 ]; then
+    if dir=$(echo "$objname" | grep -oE "^(.*)/"); then
         mkdir -p "$BASEGITDIR/$dir"
     fi
 
@@ -132,8 +131,7 @@ function download_item() {
         hash=$(echo "$objname" | sed -e 's~objects~~g' | sed -e 's~/~~g')
         
         #Check if it's valid git object
-        type=$(git cat-file -t "$hash" 2> /dev/null)
-        if [ $? -ne 0 ]; then
+        if ! type=$(git cat-file -t "$hash" 2> /dev/null); then
             #Delete invalid file
             cd "$cwd"
             rm "$target"

--- a/Extractor/extractor.sh
+++ b/Extractor/extractor.sh
@@ -44,9 +44,8 @@ function traverse_tree() {
 		name=$(echo $leaf | awk '{$1=$2=$3=""; print substr($0,4)}') #grep -oP "^\d+\s+\w{4}\s+\w{40}\s+\K.*");
 		
         # Get the blob data
-		git cat-file -e $hash;
 		#Ignore invalid git objects (e.g. ones that are missing)
-		if [ $? -ne 0 ]; then
+		if ! git cat-file -e $hash; then
 			continue;
 		fi	
 		


### PR DESCRIPTION
This makes the code much cleaerer to read.